### PR TITLE
.travis.yml: disable email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ after_script: curl -X POST http://readthedocs.org/build/limnoria-doc
 # Flags used here, not in `make html`:
 #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
 #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
+notifications:
+    email: false
+matrix:
+    fast_finish: true


### PR DESCRIPTION
and enable fast-finish even if it might not be needed yet, but it can be helpful in the future if we add more builds.
