### PR TITLE
use/install.rst: use `sudo`

### DIFF
--- a/use/install.rst
+++ b/use/install.rst
@@ -82,19 +82,19 @@ which setup you should specify to have UNIX tools in PATH.
 Global installation
 ^^^^^^^^^^^^^^^^^^^
 
-You can either run these as root or prepend ``sudo`` in front of every 
-message.
+If you are logged in as root, you can remove ``sudo`` from the install 
+commands.
 
 In case you want to use the testing branch which might be more up-to date 
 **but less tested**, replace ``master`` with ``testing`` in the commands.
 
 First we install Limnoria's requirements::
 
-    pip install -r https://raw.githubusercontent.com/ProgVal/Limnoria/master/requirements.txt --upgrade
+    sudo pip install -r https://raw.githubusercontent.com/ProgVal/Limnoria/master/requirements.txt --upgrade
 
 And then Limnoria itself::
 
-    pip install git+https://github.com/ProgVal/Limnoria.git@master --upgrade
+    sudo pip install git+https://github.com/ProgVal/Limnoria.git@master --upgrade
 
 Local installation
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
With help from #supybot I understood that telling user to add `sudo` in
front of every command isn't very user-friendly.

If someone has root and is logged in as root, they know to remove the
`sudo` part and if they don't, but they have `sudo` installed,
everything works directly and `sudo` doesn't even ask for password.
