### PR TITLE
install.rst: put part about testing in italics

### DIFF
--- a/use/install.rst
+++ b/use/install.rst
@@ -86,8 +86,8 @@ Global installation
 If you are logged in as root, you can remove ``sudo`` from the install 
 commands.
 
-In case you want to use the testing branch which might be more up-to date 
-**but less tested**, replace ``master`` with ``testing`` in the commands.
+*In case you want to use the testing branch which might be more up-to 
+date BUT LESS TESTED, replace ``master`` with ``testing`` in the commands.*
 
 First we install Limnoria's requirements::
 


### PR DESCRIPTION
I think people are missing that part even if they are sure that they want to use it. This makes it to be in italics which might be more visible and capitalizes "BUT LESS TESTED". I couldn't find out how would I make it bold inside italics, but I think that caps are enough visible.
