### PR TITLE
use/install.rst: remove accidental $s

### DIFF
--- a/use/install.rst
+++ b/use/install.rst
@@ -114,8 +114,8 @@ You might need to add $HOME/.local/bin to your PATH.::
     echo 'PATH="$HOME/.local/bin:$PATH"' >> ~/.$(echo $SHELL|cut -d/ -f3)rc
     source ~/.$(echo $SHELL|cut -d/ -f3)rc
 
-If pip gives error immediately instead of doing anything and you have git$
-installd, try upgrading pip with ``pip install pip --upgrade --user``.$
+If pip gives error immediately instead of doing anything and you have git
+installd, try upgrading pip with ``pip install pip --upgrade --user``.
 
 Configure Supybot
 -----------------


### PR DESCRIPTION
My Vimrc makes Vim show $ where line changes and I had accidentally
copy-pasted it to places where it doesn't belong.
