### PR TITLE
use/install.rst: use python -m pip instead of pip

### DIFF
--- a/use/install.rst
+++ b/use/install.rst
@@ -98,7 +98,7 @@ And then Limnoria itself::
     sudo python -m pip install git+https://github.com/ProgVal/Limnoria.git@master --upgrade
 
 If pip gives error immediately instead of doing anything and you have git
-installd, try upgrading pip with ``sudo python -m pip install pip --upgrade``.
+installed, try upgrading pip with ``sudo python -m pip install pip --upgrade``.
 
 Local installation
 ^^^^^^^^^^^^^^^^^^
@@ -115,7 +115,7 @@ You might need to add $HOME/.local/bin to your PATH.::
     source ~/.$(echo $SHELL|cut -d/ -f3)rc
 
 If pip gives error immediately instead of doing anything and you have git
-installd, try upgrading pip with ``python -m pip install pip --upgrade --user``.
+installed, try upgrading pip with ``python -m pip install pip --upgrade --user``.
 
 Configure Supybot
 -----------------


### PR DESCRIPTION
Windows pip cannot update itself so Windows instructions need a little fixing and having both formats could cause confusion. Specifying python also can make which pip uses as more clear as pypy doesn't seem to get it's own binary for pip and no binary links there.

Links:
- http://pip.readthedocs.org/en/latest/installing.html#upgrade-pip
  - http://pip.readthedocs.org/en/latest/installing.html#id11
    - https://github.com/pypa/pip/issues/1299
