### PR TITLE
conf.py: fix title

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -113,7 +113,7 @@ pygments_style = 'sphinx'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title =  'Limnoria\'s documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
before: Limnoria 0.83.4.1+limnoria documentation
After: Limnoria's documentation

The first one is ugly, because it says Limnoria twice and the version
number is always the same so why do we store it everywhere?
