### PR TITLE
advanced_plugin_testing: fix underline

### DIFF
--- a/develop/advanced_plugin_testing.rst
+++ b/develop/advanced_plugin_testing.rst
@@ -201,7 +201,7 @@ And now you can be assured that supybot.commands.nested is going to be off for
 all of your test methods in this test case class.
 
 Temporarily setting a configuration variable
-------------------------------------------
+--------------------------------------------
 
 Sometimes we want to change a configuration variable only in a test (or in
 a part of a test), and keep the original value for other tests. The


### PR DESCRIPTION
Next error is something where I cannot say anything.

```
/home/mikaela/src/github/mikaela/limnoria-doc/develop/callbacks.rst:11:
WARNING: py:class reference target not found: NestedCommandsIrcProxy
```
