### PR TITLE
Revise and condense the plugin tutorial

### DIFF
--- a/develop/advanced_plugin_config.rst
+++ b/develop/advanced_plugin_config.rst
@@ -17,110 +17,13 @@ handled there first.
 
 In this tutorial we'll cover:
 
-* Using the configure function more effectively by using the functions
-  provided in supybot.questions
 * Creating config variable groups and config variables underneath those
   groups.
 * The built-in config variable types ("registry types") for use with config
   variables
 * Creating custom registry types to handle config variable values more
   effectively
-
-Using 'configure' effectively
-=============================
-  How to use 'configure' effectively using the functions from
-  'supybot.questions'
-
-In the original Supybot plugin author tutorial you'll note that we gloss over
-the configure portion of the config.py file for the sake of keeping the
-tutorial to a reasonable length. Well, now we're going to cover it in more
-detail.
-
-The supybot.questions module is a nice little module coded specifically to help
-clean up the configure section of every plugin's config.py. The boilerplate
-config.py code imports the four most useful functions from that module:
-
-* "expect" is a very general prompting mechanism which can specify certain
-  inputs that it will accept and also specify a default response. It takes
-  the following arguments:
-
-    * prompt: The text to be displayed
-    * possibilities: The list of possible responses (can be the empty
-      list, [])
-    * default (optional): Defaults to None. Specifies the default value
-      to use if the user enters in no input.
-    * acceptEmpty (optional): Defaults to False. Specifies whether or not
-      to accept no input as an answer.
-
-* "anything" is basically a special case of expect which takes anything
-  (including no input) and has no default value specified. It takes only
-  one argument:
-
-    * prompt: The text to be displayed
-
-* "something" is also a special case of expect, requiring some input and
-  allowing an optional default. It takes the following arguments:
-
-    * prompt: The text to be displayed
-    * default (optional): Defaults to None. The default value to use if
-      the user doesn't input anything.
-
-* "yn" is for "yes or no" questions and basically forces the user to input
-  a "y" for yes, or "n" for no. It takes the following arguments:
-
-    * prompt: The text to be displayed
-    * default (optional): Defaults to None. Default value to use if the
-      user doesn't input anything.
-
-All of these functions, with the exception of "yn", return whatever string
-results as the answer whether it be input from the user or specified as the
-default when the user inputs nothing. The "yn" function returns True for "yes"
-answers and False for "no" answers.
-
-For the most part, the latter three should be sufficient, but we expose expect
-to anyone who needs a more specialized configuration.
-
-Let's go through a quick example configure that covers all four of these
-functions. First I'll give you the code, and then we'll go through it,
-discussing each usage of a supybot.questions function just to make sure you
-realize what the code is actually doing. Here it is::
-
-  def configure(advanced):
-      # This will be called by supybot to configure this module.  advanced is
-      # a bool that specifies whether the user identified himself as an advanced
-      # user or not.  You should effect your configuration by manipulating the
-      # registry as appropriate.
-      from supybot.questions import expect, anything, something, yn
-      WorldDom = conf.registerPlugin('WorldDom', True)
-      if yn("""The WorldDom plugin allows for total world domination
-               with simple commands.  Would you like these commands to
-               be enabled for everyone?""", default=False):
-          WorldDom.globalWorldDominationRequires.setValue("")
-      else:
-          cap = something("""What capability would you like to require for
-                             this command to be used?""", default="Admin")
-          WorldDom.globalWorldDominationRequires.setValue(cap)
-      dir = expect("""What direction would you like to attack from in
-                      your quest for world domination?""",
-                   ["north", "south", "east", "west", "ABOVE"],
-                   default="ABOVE")
-      WorldDom.attackDirection.setValue(dir)
-
-As you can see, this is the WorldDom plugin, which I am currently working on.
-The first thing our configure function checks is to see whether or not the bot
-owner would like the world domination commands in this plugin to be available
-to everyone. If they say yes, we set the globalWorldDominationRequires
-configuration variable to the empty string, signifying that no specific
-capabilities are necessary. If they say no, we prompt them for a specific
-capability to check for, defaulting to the "Admin" capability. Here they can
-create their own custom capability to grant to folks which this plugin will
-check for if they want, but luckily for the bot owner they don't really have to
-do this since Supybot's capabilities system can be flexed to take care of this.
-
-Lastly, we check to find out what direction they want to attack from as they
-venture towards world domination. I prefer "death from above!", so I made that
-the default response, but the more boring cardinal directions are available as
-choices as well.
+* Using the configure function for interactive configuration in supybot-wizard
 
 Using Config Groups
 ===================
@@ -441,6 +344,102 @@ variable using it::
 Note that we initialize it just the same as we do any other registry type, with
 two arguments: the default value, and then the description of the config
 variable.
+
+Using 'configure' for supybot-wizard support
+============================================
+  How to use 'configure' effectively using the functions from
+  'supybot.questions'
+
+In the original Supybot plugin author tutorial you'll note that we gloss over
+the configure portion of the config.py file for the sake of keeping the
+tutorial to a reasonable length. Well, now we're going to cover it in more
+detail.
+
+The supybot.questions module is a nice little module coded specifically to help
+clean up the configure section of every plugin's config.py. The boilerplate
+config.py code imports the four most useful functions from that module:
+
+* "expect" is a very general prompting mechanism which can specify certain
+  inputs that it will accept and also specify a default response. It takes
+  the following arguments:
+
+    * prompt: The text to be displayed
+    * possibilities: The list of possible responses (can be the empty
+      list, [])
+    * default (optional): Defaults to None. Specifies the default value
+      to use if the user enters in no input.
+    * acceptEmpty (optional): Defaults to False. Specifies whether or not
+      to accept no input as an answer.
+
+* "anything" is basically a special case of expect which takes anything
+  (including no input) and has no default value specified. It takes only
+  one argument:
+
+    * prompt: The text to be displayed
+
+* "something" is also a special case of expect, requiring some input and
+  allowing an optional default. It takes the following arguments:
+
+    * prompt: The text to be displayed
+    * default (optional): Defaults to None. The default value to use if
+      the user doesn't input anything.
+
+* "yn" is for "yes or no" questions and basically forces the user to input
+  a "y" for yes, or "n" for no. It takes the following arguments:
+
+    * prompt: The text to be displayed
+    * default (optional): Defaults to None. Default value to use if the
+      user doesn't input anything.
+
+All of these functions, with the exception of "yn", return whatever string
+results as the answer whether it be input from the user or specified as the
+default when the user inputs nothing. The "yn" function returns True for "yes"
+answers and False for "no" answers.
+
+For the most part, the latter three should be sufficient, but we expose expect
+to anyone who needs a more specialized configuration.
+
+Let's go through a quick example configure that covers all four of these
+functions. First I'll give you the code, and then we'll go through it,
+discussing each usage of a supybot.questions function just to make sure you
+realize what the code is actually doing. Here it is::
+
+  def configure(advanced):
+      # This will be called by supybot to configure this module.  advanced is
+      # a bool that specifies whether the user identified himself as an advanced
+      # user or not.  You should effect your configuration by manipulating the
+      # registry as appropriate.
+      from supybot.questions import expect, anything, something, yn
+      WorldDom = conf.registerPlugin('WorldDom', True)
+      if yn("""The WorldDom plugin allows for total world domination
+               with simple commands.  Would you like these commands to
+               be enabled for everyone?""", default=False):
+          WorldDom.globalWorldDominationRequires.setValue("")
+      else:
+          cap = something("""What capability would you like to require for
+                             this command to be used?""", default="Admin")
+          WorldDom.globalWorldDominationRequires.setValue(cap)
+      dir = expect("""What direction would you like to attack from in
+                      your quest for world domination?""",
+                   ["north", "south", "east", "west", "ABOVE"],
+                   default="ABOVE")
+      WorldDom.attackDirection.setValue(dir)
+
+As you can see, this is the WorldDom plugin, which I am currently working on.
+The first thing our configure function checks is to see whether or not the bot
+owner would like the world domination commands in this plugin to be available
+to everyone. If they say yes, we set the globalWorldDominationRequires
+configuration variable to the empty string, signifying that no specific
+capabilities are necessary. If they say no, we prompt them for a specific
+capability to check for, defaulting to the "Admin" capability. Here they can
+create their own custom capability to grant to folks which this plugin will
+check for if they want, but luckily for the bot owner they don't really have to
+do this since Supybot's capabilities system can be flexed to take care of this.
+
+Lastly, we check to find out what direction they want to attack from as they
+venture towards world domination. I prefer "death from above!", so I made that
+the default response, but the more boring cardinal directions are available as
+choices as well.
 
 .. _configuration-hooks:
 

--- a/develop/advanced_plugin_testing.rst
+++ b/develop/advanced_plugin_testing.rst
@@ -1,3 +1,5 @@
+.. _plugin-testing-guide:
+
 ***********************
 Advanced Plugin Testing
 ***********************
@@ -227,6 +229,8 @@ But there is a more compact syntax, using context managers::
             with conf.supybot.commands.nested.context(False):
                 # stuff
 
+.. _plugin-test-methods:
+
 Plugin Test Methods
 ===================
   The full list of test methods and how to use them.
@@ -292,7 +296,7 @@ assertActionRegexp(query, regexp, flags=re.I)
 Utilities
 ---------
 
-feedMsg(query, to=None, frm=None) 
+feedMsg(query, to=None, frm=None)
     Simply feeds query to whoever is
     specified in to or to the bot itself if no one is specified. Can also
     optionally specify the hostmask of the sender with the frm keyword.

--- a/develop/events.rst
+++ b/develop/events.rst
@@ -28,6 +28,8 @@ When a plugin is unloaded (or is to be reloaded), the ``die``
 method is called (with no parameter).
 Also make sure you always call the parent's ``die``.
 
+.. _do-method-handlers:
+
 Commands and numerics
 =====================
 

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -73,56 +73,28 @@ prompted in :command:`supybot-plugin-create`. Feel free to use whatever
 license you choose: the default is the bot's 3-clause BSD. For our example,
 we'll leave it as is.
 
-The plugin docstring immediately follows the copyright notice and it (like
-:file:`README.md`) tells you precisely what it should contain:
+Here is a list of attributes you should usually look at:
 
-The "wizard" that it speaks of is the :command:`supybot-wizard` script that is
-used to create working Limnoria config file. I imagine that in meeting the
-prerequisite of "using a Limnoria" first, most readers will have already
-encountered this script. Basically, if the user selects to look at this plugin
-from the list of plugins to load, it prints out that description to let the
-user know what it does, so make sure to be clear on what the purpose of the
-plugin is. This should be an abbreviated version of what we put in our
-:file:`README.txt`, so let's put this::
+* ``__version__``: the plugin version. We'll just make ours "0.1"
+* ``__author__`` should be an instance of the :class:`supybot.Author` class.
+  This optionally includes a full name, a short name (usually IRC nick), and
+  an e-mail address::
 
-    Provides a number of commands for selecting random things.
+    __author__ = supybot.Author(name='Daniel DiPaolo', nick='Strike',
+                                email='somewhere@someplace.xxx')
 
-Next in :file:`__init__.py` you see a few imports which are necessary, and
-then four attributes that you need to modify for your bot and preferably keep
-up with as you develop it: ``__version__``, ``__author__``,
-``__contributors__``, ``__url__``.
+* ``__contributors__`` is a dictionary mapping :class:`supybot.Author`
+  instances to lists of things they contributed. See e.g. `in the Plugin plugin
+  <https://github.com/progval/Limnoria/blob/master/plugins/Plugin/__init__.py#L42-L49>`_.
+  For now we have no contributors, so we'll leave it blank.
 
-``__version__`` is just a version string representing the current working
-version of the plugin, and can be anything you want. If you use some sort of
-RCS, this would be a good place to have it automatically increment the version
-string for any time you edit any of the files in this directory. We'll just
-make ours "0.1".
-
-``__author__`` should be an instance of the :class:`supybot.Author` class. A
-:class:`supybot.Author` is simply created by giving it a full name, a short
-name (preferably IRC nick), and an e-mail address (all of these are optional,
-though at least the second one is expected). So, for example, to create my
-Author user (though I get to cheat and use supybot.authors.strike since I'm a
-main dev, muahaha), I would do::
-
-    __author__ = supybot.Author('Daniel DiPaolo', 'Strike',
-                                'somewhere@someplace.xxx')
-
-Keep this in mind as we get to the next item...
-
-``__contributors__`` is a dictionary mapping supybot.Author instances to lists
-of things they contributed. For example, if someone adds a command named ``foo``
-to your plugin, the list for that author could be ``["added foo command"]``.
-The main author shouldn't be referenced here, as it is assumed that everything
-that wasn't contributed by someone else was done by the main author.
-For now we have no contributors, so we'll leave it blank.
-
-Lastly, the ``__url__`` attribute should just reference the download URL for
-the plugin. Since this is just an example, we'll leave this blank.
+* ``__url__`` references the download URL for the plugin. Since this is just an
+  example, we'll leave this blank.
 
 The rest of :file:`__init__.py` really shouldn't be touched unless you are
-using third-party modules in your plugin. If you are, then you need to take
-special note of the section that looks like this::
+using third-party modules in your plugin. If you are, then you need to add
+additional import statements and ``reload`` calls to all those modules, so that
+they get reloaded with the rest of the plugin::
 
     from . import config
     from . import plugin
@@ -132,69 +104,29 @@ special note of the section that looks like this::
     # to be reloaded when this plugin is reloaded.  Don't forget to
     # import them as well!
 
-As the comment says, this is one place where you need to make sure you import
-the third-party modules, and that you call :func:`reload` on them as well.
-That way, if we are reloading a plugin on a running bot it will actually
-reload the latest code. We aren't using any third-party modules, so we can
-just leave this bit alone.
-
-We're almost through the "boring" part and into the guts of writing Limnoria
-plugins, let's take a look at the next file.
-
 config.py
 =========
 :file:`config.py` is, unsurprisingly, where all the configuration stuff
-related to your plugin goes. If you're not familiar with Limnoria's
-configuration system, I recommend reading the
-:ref:`config tutorial <configuration-tutorial>` before going any
-further with this section.
+related to your plugin goes. For this tutorial, the Random plugin is simple
+enough that it doesn't need any config variables, so this file can be left as
+is.
 
-So, let's plow through config.py line-by-line like we did the other files.
+To briefly outline this file's structure: the ``configure`` function is used by
+the :command:`supybot-wizard` wizard and allows users to configure the plugin
+further if it's present when the bot is first installed. (In practice though,
+this is seldomly used by third-party plugins as they're generally installed
+*after* configuring the bot.)
 
-Once again, at the top is the standard copyright notice. Again, change it to
-how you see fit.
-
-Then, some standard imports which are necessary.
-
-Now, the first peculiar thing we get to is the configure function. This
-function is what is called by the supybot-wizard whenever a plugin is selected
-to be loaded. Since you've used the bot by now (as stated on the first page of
-this tutorial as a prerequisite), you've seen what this script does to
-configure plugins. The wizard allows the bot owner to choose something
-different from the default plugin config values without having to do it through
-the bot (which is still not difficult, but not as easy as this). Also, note
-that the advanced argument allows you to differentiate whether or not the
-person configuring this plugin considers himself an advanced Limnoria user. Our
-plugin has no advanced features, so we won't be using it.
-
-So, what exactly do we do in this configure function for our plugin? Well, for
-the most part we ask questions and we set configuration values. You'll notice
-the import line with supybot.questions in it. That provides some nice
-convenience functions which are used to (you guessed it) ask questions. The
-other line in there is the conf.registerPlugin line which registers our plugin
-with the config and allows us to create configuration values for the plugin.
-You should leave these two lines in even if you don't have anything else to put
-in here. For the vast majority of plugins, you can leave this part as is, so we
-won't go over how to write plugin configuration functions here (that will be
-handled in a separate article). Our plugin won't be using much configuration,
-so we'll leave this as is.
-
-Next, you'll see a line that looks very similar to the one in the configure
-function. This line is used not only to register the plugin prior to being
-called in configure, but also to store a bit of an alias to the plugin's config
-group to make things shorter later on. So, this line should read::
+The following line registers an entry for the plugin in Limnoria's config
+registry, followed by any configuration groups and variable definitions::
 
     Random = conf.registerPlugin('Random')
+    # This is where your configuration variables (if any) should go.  For example:
+    # conf.registerGlobalValue(Random, 'someConfigVariableName',
+    #     registry.Boolean(False, _("""Help for someConfigVariableName.""")))
 
-Now we get to the part where we define all the configuration groups and
-variables that our plugin is to have. Again, many plugins won't require any
-configuration so we won't go over it here, but in a separate article dedicated
-to sprucing up your config.py for more advanced plugins. Our plugin doesn't
-require any config variables, so we actually don't need to make any changes to
-this file at all.
-
-Configuration of plugins is handled in depth at the Advanced Plugin Config
-Tutorial
+Writing plugin configuration is explained in depth
+in the :ref:`Advanced Plugin Config Tutorial <configuration-tutorial>`.
 
 plugin.py
 =========

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -177,9 +177,15 @@ an ``irc`` argument in addition to ``self``.
 Basic command handler
 ---------------------
 
-Our first command definition can immediately follow::
+Our first command definition can immediately follow:
 
-    # dummy comment to indent the below code consistently
+..
+    note: turn off automatic dedent so that the functions appear at the right
+    indent level relative to the class definition
+
+.. code-block::
+    :dedent: 0
+
         @wrap
         def random(self, irc, msg, args):
             """takes no arguments
@@ -225,9 +231,11 @@ Command handler with parameters
 -------------------------------
 
 Now let's create a command with some arguments and see how we use those in our
-plugin commands. This ``seed`` command lets the user pick a specific RNG seed::
+plugin commands. This ``seed`` command lets the user pick a specific RNG seed:
 
-    # dummy comment to indent the below code consistently
+.. code-block::
+    :dedent: 0
+
         @wrap(['float'])
         def seed(self, irc, msg, args, seed):
             """<seed>
@@ -266,9 +274,11 @@ we'll go include some more examples to illustrate common patterns.
 Command handler with list-type arguments
 ----------------------------------------
 The next sample command is named ``sample`` (no pun intended): it takes a random
-sample of arbitrary size from a list provided by the user::
+sample of arbitrary size from a list provided by the user:
 
-    # dummy comment to indent the below code consistently
+.. code-block::
+    :dedent: 0
+
         def sample(self, irc, msg, args, n, items):
             """<number of items> <item1> [<item2> ...]
 
@@ -279,7 +289,7 @@ sample of arbitrary size from a list provided by the user::
             if n > len(items):
                 # Calling irc.error with Raise=True is an alternative early return
                 irc.error('<number of items> must be less than the number '
-                          'of arguments.', Raise=True)
+                        'of arguments.', Raise=True)
             sample = self.rng.sample(items, n)
             sample.sort()
             irc.reply(utils.str.commaAndify(sample))
@@ -313,9 +323,11 @@ Command handler with optional arguments
 ---------------------------------------
 Now for the last command that we will add to our plugin.py. This ``diceroll``
 command will allow the bot users to roll an arbitrary n-sided die, with n
-defaulting to 6::
+defaulting to 6:
 
-    # dummy comment to indent the below code consistently
+.. code-block::
+    :dedent: 0
+
         def diceroll(self, irc, msg, args, n):
             """[<number of sides>]
 
@@ -384,9 +396,11 @@ the result will be::
 However, this is less true if you pre-seed the RNG, as then you're guaranteed
 a repeatable result. The following snippet introduces
 ``assertResponse(commandPlusArgs, expectedOutput)``, where ``commandPlusArgs``
-is the full bot command including arguments, all as one string::
+is the full bot command including arguments, all as one string:
 
-    # dummy comment to indent the below code consistently
+.. code-block::
+    :dedent: 0
+
         def testSeed(self):
             self.assertNotError('seed 20')
             self.assertResponse('random', '0.9056396761745207')
@@ -397,9 +411,11 @@ is the full bot command including arguments, all as one string::
             self.assertResponse('random', '0.9664535356921388')
 
 Alternatively, you can use ``getMsg(command)`` to fetch the output of a bot
-command as a string and reuse it::
+command as a string and reuse it:
 
-    # dummy comment to indent the below code consistently
+.. code-block::
+    :dedent: 0
+
         def testSeed(self):
             self.assertNotError('seed 20')
             num1 = self.getMsg('random')
@@ -420,9 +436,9 @@ a command:
   compares a regexp against a bare string, not the output of a bot command.
   (For historical reasons, we have this confusing name.)
 
-::
+.. code-block::
+    :dedent: 0
 
-    # dummy comment to indent the below code consistently
         def testSample(self):
             self.assertError('sample 20 foo')  # can't sample 20 from only 1 element
             self.assertResponse('sample 1 foo', 'foo')

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -194,7 +194,7 @@ arguments; they are as follows:
 - ``self``: refers to the class instance. It is common to keep local state
   for the plugin as instance variables within the plugin class.
 - ``irc``: refers to the IRC network instance the command was called on
-- ``msg``: a :ref:`supybot.ircmsgs <supybot-ircmsgs>` instance; refers to the
+- ``msg``: a :class:`supybot.ircmsgs.IrcMsg` instance; refers to the
   IRC message that triggered this command.
 - ``args``: a raw list of remaining unconverted arguments; new plugins that
   use :ref:`@wrap <using-wrap>` for automatic argument type conversion should

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -279,6 +279,7 @@ sample of arbitrary size from a list provided by the user:
 .. code-block::
     :dedent: 0
 
+        @wrap(['int', many('anything')])
         def sample(self, irc, msg, args, n, items):
             """<number of items> <item1> [<item2> ...]
 
@@ -289,11 +290,10 @@ sample of arbitrary size from a list provided by the user:
             if n > len(items):
                 # Calling irc.error with Raise=True is an alternative early return
                 irc.error('<number of items> must be less than the number '
-                        'of arguments.', Raise=True)
+                          'of arguments.', Raise=True)
             sample = self.rng.sample(items, n)
             sample.sort()
             irc.reply(utils.str.commaAndify(sample))
-        sample = wrap(sample, ['int', many('anything')])
 
 The important thing to note is that list type arguments are rolled into one
 parameter in the command function by the ``many`` filter. Similar "multiplicity"
@@ -328,6 +328,7 @@ defaulting to 6:
 .. code-block::
     :dedent: 0
 
+        @wrap([additional(('int', 'number of sides'), 6)])
         def diceroll(self, irc, msg, args, n):
             """[<number of sides>]
 
@@ -336,7 +337,6 @@ defaulting to 6:
             """
             s = 'rolls a %s' % self.rng.randrange(1, n)
             irc.reply(s, action=True)
-        diceroll = wrap(diceroll, [additional(('int', 'number of sides'), 6)])
 
 The only new thing described here is that ``irc.reply(..., action=True)`` makes
 the bot perform a `/me`. There are some other flags described in the

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -6,37 +6,32 @@ Writing Your First Limnoria Plugin
 
 Introduction
 ============
-Ok, so you want to write a plugin for Limnoria. Good, then this is the place to
-be. We're going to start from the top (the highest level, where Limnoria code
-does the most work for you) and move lower after that.
 
-So have you used Limnoria? If not, you need to go use it. This will help you
-understand crucial things like the way the various commands work and it is
-essential prior to embarking upon the plugin-development excursion detailed in
-the following pages. If you haven't used Limnoria, come back to this document
-after you've used it for a while and gotten a feel for it.
+This page is a top-down guide on how to write new plugins for Limnoria.
 
-So, now that we know you've used Limnoria, we'll start getting into details.
+Before you start, you should be more-or-less familiar with how to use and
+manage a Limnoria instance (loading plugins, configuring options, etc.).
+You should also install a copy of Limnoria on the machine you intend to develop
+plugins on, as it includes some additional scripts like
+:command:`supybot-plugin-create` to generate the plugin skeleton.
+
 We'll go through this tutorial by actually writing a new plugin, named Random
-with just a few simple commands.
+with just a few commands.
 
-    Caveat: you'll need to have Limnoria installed on the machine you
-    intend to develop plugins on. This will not only allow you to test
-    the plugins with a live bot, but it will also provide you with
-    several nice scripts which aid the development of plugins. Most
-    notably, it provides you with the supybot-plugin-create script which
-    we will use in the next section...  Creating a minimal plugin This
-    section describes using the 'supybot-plugin-create' script to create
-    a minimal plugin which we will enhance in later sections.
+Generating the Plugin template
+==============================
 
-The recommended way to start writing a plugin is to use the wizard provided,
-:command:`supybot-plugin-create`. Run this from within your local plugins
-directory, so we will be able to load the plugin and test it out.
+The recommended way to start writing a plugin is to use the
+:command:`supybot-plugin-create` wizard. You can run this from within your bot's
+plugins directory, or make a separate directory for all your own plugins and run
+it there. (You can add additional plugin directories to your bot config using
+``config directories.plugins``). The latter approach is probably easier if you
+intend to publish your code afterwards, as it keeps your code separate from any
+other plugins you've installed.
 
-It's very easy to follow, because basically all you have to do is answer three
-questions. Here's an example session::
+Here's an example session::
 
-    [ddipaolo@quinn ../python/supybot]% supybot-plugin-create
+    $ supybot-plugin-create
     What should the name of the plugin be? Random
 
     Sometimes you'll want a callback to be threaded.  If its methods
@@ -46,61 +41,40 @@ questions. Here's an example session::
 
     Does your plugin need to be threaded? [y/n] n
 
-    What is your real name, so I can fill in the copyright and license
-    appropriately? Daniel DiPaolo
+    What is your name, so I can fill in the copyright and license
+    appropriately? John Doe
 
-    Your new plugin template is in the Random directory.
+    Do you wish to use Supybot's license for your plugin? [y/n] y
 
-It's that simple! Well, that part of making the minimal plugin is that simple.
-You should now have a directory with a few files in it, so let's take a look at
-each of those files and see what they're used for.
+    Please provide a short description of the plugin: This plugin contains
+    commands relating to random numbers, including random sampling from a list
+    and a simple dice roller.
 
 README.md
 ==========
-Open the file with notepad just as if it was a .txt file. In `README.md` you put exactly what the boilerplate text says to put in
-there:
 
-    Insert a description of your plugin here, with any notes, etc. about
-    using it.
+This is the README page people will see when they download your plugin or view
+it from a source control website. It's helpful to include a brief summary of
+what the plugin does here, as well as list any third-party dependencies.
 
-A brief overview of exactly what the purpose of the plugin is supposed to do is
-really all that is needed here. Also, if this plugin requires any third-party
-Python modules, you should definitely mention those here. You don't have to
-describe individual commands or anything like that, as those are defined within
-the plugin code itself as you'll see later. You also don't need to acknowledge
-any of the developers of the plugin as those too are handled elsewhere.
-
-For our Random plugin, let's make :file:`README.md` say this:
-
-    This plugin contains commands relating to random numbers, and
-    includes: a simple random number generator, the ability to pick a
-    random number from within a range, a command for returning a random
-    sampling from a list of items, and a simple dice roller.
-
-And now you know what's in store for the rest of this tutorial, we'll be
-writing all of that in one Limnoria plugin, and you'll be surprised at just how
-simple it is!
+The :command:`supybot-plugin-create` wizard should have already filled in the
+README with the summary you provided.
 
 __init__.py
 ===========
-The next file we'll look at is :file:`__init__.py`. If you're familiar with
-the Python import mechanism, you'll know what this file is for. If you're not,
-think of it as sort of the "glue" file that pulls all the files in this
-directory together when you load the plugin. It's also where there are a few
-administrative items live that you really need to maintain.
+The next file we'll look at is :file:`__init__.py`. If you're not so familiar
+with the Python import mechanism, think of it as sort of the "glue" file that
+pulls all the files in the plugin directory together when you load it.
+There are also a few administrative items here that can be queried from the bot,
+such as the plugin's author and contact info.
 
-Let's go through the file. For the first 30 lines or so, you'll see the
-copyright notice that we use for our plugins, only with your name in place (as
-prompted in :command:`supybot-plugin-create`). Feel free to use whatever
-license you choose, we don't feel particularly attached to the boilerplate
-code so it's yours to license as you see fit even if you don't modify it. For
-our example, we'll leave it as is.
+At the top of the file you'll see the copyright header, with your name added as
+prompted in :command:`supybot-plugin-create`. Feel free to use whatever
+license you choose: the default is the bot's 3-clause BSD. For our example,
+we'll leave it as is.
 
 The plugin docstring immediately follows the copyright notice and it (like
-:file:`README.txt`) tells you precisely what it should contain:
-
-    Add a description of the plugin (to be presented to the user inside
-    the wizard) here.  This should describe *what* the plugin does.
+:file:`README.md`) tells you precisely what it should contain:
 
 The "wizard" that it speaks of is the :command:`supybot-wizard` script that is
 used to create working Limnoria config file. I imagine that in meeting the

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -165,11 +165,14 @@ For this sample plugin, we define a custom constructor (``__init__``) that
 instantiates a random number generator instance and pre-seeds it. This isn't
 technically necessary for Python's ``random`` module, but it helps outline
 how to write a similar constructor. Notice in particular how you must pass in
-the ``irc`` argument in addition to ``self``.
+an ``irc`` argument in addition to ``self``.
 
-.. note::
-    TODO(jlu): semantically, what does ``irc`` refer to? Most plugins don't
-    actually reference it on load time.
+.. warning::
+    Because Limnoria is a multi-network bot, you should generally ignore
+    the ``irc`` instance passed to the plugin constructor.
+    On a manual ``load`` call to a live bot, this will be set to the network
+    the command was run on, but on bot startup, ``irc`` will be (arbitrarily)
+    set to the first network that the bot decides to connect to.
 
 Basic command handler
 ---------------------

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -75,7 +75,7 @@ we'll leave it as is.
 
 Here is a list of attributes you should usually look at:
 
-* ``__version__``: the plugin version. We'll just make ours "0.1"
+* ``__version__``: the plugin version. We'll make ours `"0.1"`
 * ``__author__`` should be an instance of the :class:`supybot.Author` class.
   This optionally includes a full name, a short name (usually IRC nick), and
   an e-mail address::
@@ -148,9 +148,7 @@ the plugin, though this is not strictly required (the actual linkage is done by
 the ``Class = Random`` statement at the end of the file). It is helpful to fill
 in the plugin docstring with some more details on how to actually use the plugin
 too: this info can be shown on a live bot using the
-``plugin help <plugin name>`` command.
-
-::
+``plugin help <plugin name>`` command. ::
 
     class Random(callbacks.Plugin):
         """This plugin contains commands relating to random numbers, including random sampling from a list and a simple dice roller."""
@@ -202,7 +200,8 @@ arguments; they are as follows:
 
 - ``self``: refers to the class instance. It is common to keep local state
   for the plugin as instance variables within the plugin class.
-- ``irc``: refers to the IRC network instance the command was called on
+- ``irc``: a :class:`supybot.callbacks.ReplyIrcProxy` instance; refers to the
+  IRC network instance the command was called on
 - ``msg``: a :class:`supybot.ircmsgs.IrcMsg` instance; refers to the
   IRC message that triggered this command.
 - ``args``: a raw list of remaining unconverted arguments; new plugins that
@@ -218,7 +217,7 @@ it to make it look nice. This part should be fairly brief but sufficient to
 explain the function and what (if any) arguments it requires. Remember that this
 should fit in one IRC message which is typically around a 450 character limit.
 
-The :py:meth:`irc.reply <supybot.callbacks.NestedCommandsIrcProxy.reply>` call
+The :py:meth:`irc.reply <supybot.callbacks.ReplyIrcProxy.reply>` call
 is a bit of magic: it issues a reply the same place as the message that
 triggered the command. i.e. this may be in a channel or in a private
 conversation with the bot.
@@ -303,16 +302,16 @@ We also update the docstring to use the ``[]`` convention when surrounding
 optional arguments.
 
 For this function's body,
-:py:meth:`irc.error <supybot.callbacks.NestedCommandsIrcProxy.error>`
+:py:meth:`irc.error <supybot.callbacks.ReplyIrcProxy.error>`
 is like
-:py:meth:`irc.replySuccess <supybot.callbacks.NestedCommandsIrcProxy.replySuccess>`
+:py:meth:`irc.replySuccess <supybot.callbacks.ReplyIrcProxy.replySuccess>`
 but for error messages. We prefer using this instead of ``irc.reply`` for error
 signaling because its behaviour can be configured specially. For example, you
 can force all errors to go in private by setting the ``reply.error.inPrivate``
 option, and this can help reduce noise on a busy channel.
 Also, ``irc.error()`` with no text will return a generic error message
 configured in ``supybot.replies.error``, but this is not a valid call to
-:py:meth:`irc.reply <supybot.callbacks.NestedCommandsIrcProxy.reply>`.
+:py:meth:`irc.reply <supybot.callbacks.ReplyIrcProxy.reply>`.
 
 ``utils.str.commaAndify`` is a simple helper that takes a list of strings
 and turns it into "item1, item2, item3, item4, and item5" for an arbitrary
@@ -340,7 +339,7 @@ defaulting to 6:
 
 The only new thing described here is that ``irc.reply(..., action=True)`` makes
 the bot perform a `/me`. There are some other flags described in the
-:py:meth:`irc.reply <supybot.callbacks.NestedCommandsIrcProxy.reply>`
+:py:meth:`irc.reply <supybot.callbacks.ReplyIrcProxy.reply>`
 documentation too: common ones include ``private=True``, which
 forces a private message, and ``notice=True``, which forces the reply to use
 NOTICE instead of PRIVMSG.

--- a/develop/plugin_tutorial.rst
+++ b/develop/plugin_tutorial.rst
@@ -91,7 +91,7 @@ Here is a list of attributes you should usually look at:
 * ``__url__`` references the download URL for the plugin. Since this is just an
   example, we'll leave this blank.
 
-The rest of :file:`__init__.py` really shouldn't be touched unless you are
+The rest of :file:`__init__.py` shouldn't be touched unless you are
 using third-party modules in your plugin. If you are, then you need to add
 additional import statements and ``reload`` calls to all those modules, so that
 they get reloaded with the rest of the plugin::
@@ -354,7 +354,7 @@ instance of the bot, in addition to the
 provided by the unittest library.
 
 Running the tests for a Limnoria plugin is done using the
-:command:`supybot-test` command: i.e. ``supybot-test /path/to/your/plugin``
+:command:`supybot-test` command: i.e. ``supybot-test /path/to/your/Plugin``
 
 The structure of these test classes, as well
 as interactions with features like Limnoria's config system are described in

--- a/develop/using_utils.rst
+++ b/develop/using_utils.rst
@@ -1,3 +1,5 @@
+.. _using-utils:
+
 ****************************
 Using Supybot's utils module
 ****************************

--- a/develop/using_wrap.rst
+++ b/develop/using_wrap.rst
@@ -154,10 +154,11 @@ it's an optional argument and if it is None, that signifies that nothing was
 there. Also, for another example, many("something") doesn't return the same
 thing that just "something" would return, but rather a list of "something"s.
 
+.. _wrap-converter-list:
+
 Converter List
 ==============
 
-.. _wrap-converter-list:
 Below is a list of all the available converters to use with wrap. If the
 converter accepts any arguments, they are listed after it and if they are
 optional, the default value is shown.

--- a/develop/using_wrap.rst
+++ b/develop/using_wrap.rst
@@ -1,3 +1,5 @@
+.. _using-wrap:
+
 *****************************************************
 Using commands.wrap to parse your command's arguments
 *****************************************************
@@ -154,6 +156,8 @@ thing that just "something" would return, but rather a list of "something"s.
 
 Converter List
 ==============
+
+.. _wrap-converter-list:
 Below is a list of all the available converters to use with wrap. If the
 converter accepts any arguments, they are listed after it and if they are
 optional, the default value is shown.
@@ -467,6 +471,8 @@ additional
 first
     Tries each of the supplied converters in order and returns the result of
     the first successfully applied converter.
+
+.. _wrap-multiplicity-handlers:
 
 Multiplicity
 ------------


### PR DESCRIPTION
Many of our doc pages haven't seen much love in over a decade, let's start with cleaning up the plugin tutorial.

In the spirit of https://justsimply.dev/, much of the focus here is to make the text less excruciatingly wordy. Developers don't need to be told basic things, like how boilerplate is boilerplate, or what an import is.
