### PR TITLE
Replace Supybook references with the Getting Started guide

### DIFF
--- a/use/install.rst
+++ b/use/install.rst
@@ -153,6 +153,4 @@ Now to start the bot, run, still from within the 'runbot' directory::
 
 And watch the magic!
 
-For a tutorial on using and managing the bot from here on, see the `Supybook`_.
-
-.. _Supybook: https://hoxu.github.io/supybook/
+For a tutorial on using and managing the bot from here on, see the :ref:`Getting Started guide <getting-started>`.

--- a/use/install_windows.rst
+++ b/use/install_windows.rst
@@ -96,5 +96,3 @@ This guide has been mainly written by nanotube (Daniel Folkinshteyn), and
 is licensed under the Creative Commons Attribution ShareAlike 3.0 Unported
 license and/or the GNU Free Documentation License v 1.3 or later.
 
-.. _Supybook: https://hoxu.github.io/supybook/
-


### PR DESCRIPTION
Supybook's last update was over 10 years ago. While it still includes some nice tips I think it's more natural to have the documentaiton be self-contained.