### PR TITLE
Rewrite the Capabilities reference

### DIFF
--- a/use/security.rst
+++ b/use/security.rst
@@ -1,3 +1,5 @@
+.. _security:
+
 ********************
 Security in Limnoria
 ********************


### PR DESCRIPTION
- Focus more on the format and usage of capabilities, as opposed to the excitement and motivation
- Change "Default capabilities" to "Special built-in capabilities" to avoid confusion with "defaultcapability add|remove"
- Split the documentation for each built-in capability into a separate section for readability
- Add specific entries for #channel,halfop and #channel,voice instead of mentioning only them in passing in a command usage example
- Flip the ordering for global and channel default capabilities. The former is IMO more likely to be more useful