### PR TITLE
plugin_tutorial: further simplifications

### DIFF
--- a/use/getting_started.rst
+++ b/use/getting_started.rst
@@ -217,6 +217,7 @@ To unload a plugin, there is a corresponding ``unload`` command::
 To find plugins to load, consult the :ref:`Built-in plugins reference <builtin-plugins-reference>`
 or the Plugins list on `limnoria.net <https://limnoria.net/plugins.xhtml>`_.
 
+.. _help-syntax:
 Understanding the help syntax
 =============================
 


### PR DESCRIPTION
- Remove the discussion of README and copyright header. These are already very self documenting
- Add links to the `help` syntax reference in use/getting_started
- Update the headings to include the contents of each file in addition to its name for easier navigation
- Further remove redundant language